### PR TITLE
Do not swallow exceptions thrown by an application if the diagnostics library fails.

### DIFF
--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -11,7 +11,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Recommended Google client library to access the Google Cloud Debugger API.</Description>
-    <PackageTags>Debug;Debugger;Debugging;Google;Cloud</PackageTags>
+    <PackageTags>Debug;Debugger;Debugging;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2017 Google Inc.</Copyright>
     <Authors>Google Inc.</Authors>
     <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
@@ -54,7 +54,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             }
             catch (Exception exception)
             {
-                await _logger.LogAsync(exception, httpContext).ConfigureAwait(false);
+                try
+                {
+                    await _logger.LogAsync(exception, httpContext).ConfigureAwait(false);
+                }
+                catch (Exception innerException)
+                {
+                    throw new AggregateException(innerException, exception);
+                }
                 throw;
             }
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -84,10 +84,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 {
                     await _next(httpContext).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (Exception exception)
                 {
-                    StackTrace stackTrace = new StackTrace(e, true);
-                    tracer.SetStackTrace(stackTrace);
+                    try
+                    {
+                        StackTrace stackTrace = new StackTrace(exception, true);
+                        tracer.SetStackTrace(stackTrace);
+                    }
+                    catch (Exception innerException)
+                    {
+                        throw new AggregateException(innerException, exception);
+                    }
                     throw;
                 }
                 finally

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -76,7 +76,7 @@
     "version": "1.0.0-alpha01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Debugger API.",
-    "tags": [ "Debug", "Debugger", "Debugging"],
+    "tags": [ "Debug", "Debugger", "Debugging", "Stackdriver"],
     "dependencies": {
       "Google.Api.Gax.Grpc": "2.0.0",
       "Google.Cloud.DevTools.Common": "1.0.0",


### PR DESCRIPTION
Currently when an exception occurs in an application and the diagnostics library needs to report this state it will and then rethrow.  However, currently if the diagnostics library throws and exception the application's exception is lost.

Fixes #1350
